### PR TITLE
Close #85 Redesign resources to make better use of screen real estate on desktop

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -534,7 +534,7 @@
 		}
 
 		.row.uniform.\35 0\25 > * {
-			padding: 1em 0 0 1em;
+			padding: 1em 3vw 0 3vw;
 		}
 
 		.row.uniform.\35 0\25 {
@@ -749,7 +749,7 @@
 		}
 
 		.row.uniform.\35 0\25 > * {
-			padding: 0.75em 0 0 0.75em;
+			padding: 0.75em 3vw 0 3vw;
 		}
 
 		.row.uniform.\35 0\25 {
@@ -964,7 +964,7 @@
 		}
 
 		.row.uniform.\35 0\25 > * {
-			padding: 0.75em 0 0 0.75em;
+			padding: 0.75em 3vw 0 3vw;
 		}
 
 		.row.uniform.\35 0\25 {
@@ -1179,7 +1179,7 @@
 		}
 
 		.row.uniform.\35 0\25 > * {
-			padding: 0.625em 0 0 0.625em;
+			padding: 0.625em 3vw 0 3vw;
 		}
 
 		.row.uniform.\35 0\25 {
@@ -4982,8 +4982,8 @@
 }
 
 #forms-table-div {
-	width:30%; 
-	margin:auto; 
+	width:30%;
+	margin:auto;
 	text-align:center;
 }
 

--- a/resources.html
+++ b/resources.html
@@ -77,7 +77,7 @@
 									<div class="6u$">
 										<h2 id="resume">Résumé Book</h2>
 										<center><p>Add your résumé here, have companies reach out to you!</p></center>
-										<center><button class="button special" onclick="window.open('https://apps.cs.utexas.edu/resume/login.scgi')"><span>Attach Resume</span></button>
+										<center><button class="button special" onclick="window.open('https://apps.cs.utexas.edu/resume/login.scgi')"><span>Attach Résumé</span></button>
 										<p style="margin-top:0px; padding-top:0px; font-size:12px"></p></center>
 									</div>
 									<div class="6u">
@@ -87,13 +87,13 @@
 									</div>
 									<div class="6u$">
 										<h2>Become an Officer</h2>
-										<center><p>Keep an eye out for OO applications in September! If you want to be a Senior Officer, our elections are held at the end of every Spring.</p>
-										<button class="button special" onclick="window.open('https://docs.google.com/forms/d/e/1FAIpQLSf4e64rhLtp3JhSsyQbUagflcCBbakcPj8zqWGgp0NYfbMA1w/viewform')"><span>Apply to be an Officer</span></button></center>
+										<center><p>Keep an eye out for OO applications in September! For Senior Officer positions, elections are held at the end of every Spring.</p>
+										<button class="button special" onclick="window.open('https://docs.google.com/forms/d/e/1FAIpQLSf4e64rhLtp3JhSsyQbUagflcCBbakcPj8zqWGgp0NYfbMA1w/viewform')"><span>Apply</span></button></center>
 									</div>
 									<div class="6u">
 										<h2>Join our Mentorship Program</h2>
 										<center><p>Our mentorship program matches upperclassmen with incoming freshman, who can help out with the social, academic, and career aspects of college. The mentorship program aims to form tight-knit friends and connections.</p>
-										<button class="button special" onclick="window.open('http://texasacm.org/forms.html?Mentorship')"><span>Sign up for our mentorship program</span></button></center>
+										<button class="button special" onclick="window.open('http://texasacm.org/forms.html?Mentorship')"><span>Sign up</span></button></center>
 									</div>
 									<div class="6u$">
 										<h2>Human Resources Contact</h2>

--- a/resources.html
+++ b/resources.html
@@ -57,83 +57,109 @@
 			<iframe src="header.html?member" frameborder="0" scrolling="no" width="100%" id="header-iframe"></iframe>
 		</header>
 
+
+
+
 		<!-- Main -->
 		<section id="main" class="wrapper">
-			<div class="inner">
-
+			<div class="inner"
 				<div class="section-separaters" id="resume-book">
-					<br>
-					<h2 id="resume">Résumé Book</h2>
-					<center><p>Add your résumé here, have companies reach out to you!</p></center>
-					<center><button class="button special" onclick="window.open('https://apps.cs.utexas.edu/resume/login.scgi')"><span>Attach Resume</span></button>
-					<p style="margin-top:0px; padding-top:0px; font-size:12px"></p></center>
-				</div>
+					<section id="two" class="wrapper content-pad">
+						<div id="events-panel">
+							<div class="box alt">
+								<div class="row uniform 50%">
+									<br>
+									<div class="6u">
+										<h2>Get Connected</h2>
+										<center><p>Join our Facebook group to stay up to date with our events!</p>
+										<button class="button special" onclick="window.open('http://facebook.com/groups/texas.acm')"><span>Visit Facebook group</span></button></center>
+									</div>
+									<div class="6u$">
+										<h2 id="resume">Résumé Book</h2>
+										<center><p>Add your résumé here, have companies reach out to you!</p></center>
+										<center><button class="button special" onclick="window.open('https://apps.cs.utexas.edu/resume/login.scgi')"><span>Attach Resume</span></button>
+										<p style="margin-top:0px; padding-top:0px; font-size:12px"></p></center>
+									</div>
+									<div class="6u">
+										<h2>Become a Member</h2>
+										<center><p>Sign up <b>today</b>! Membership is <b>FREE</b>. Access the form below and make sure to stop by <a href="about.html#office-info" target="_blank">the office</a> to say hello!</p>
+										<button class="button special" onclick="window.open('http://texasacm.org/forms.html?join')"><span>Sign Up</span></button></center>
+									</div>
+									<div class="6u$">
+										<h2>Become an Officer</h2>
+										<center><p>Keep an eye out for OO applications in September! If you want to be a Senior Officer, our elections are held at the end of every Spring.</p>
+										<button class="button special" onclick="window.open('https://docs.google.com/forms/d/e/1FAIpQLSf4e64rhLtp3JhSsyQbUagflcCBbakcPj8zqWGgp0NYfbMA1w/viewform')"><span>Apply to be an Officer</span></button></center>
+									</div>
+									<div class="6u">
+										<h2>Join our Mentorship Program</h2>
+										<center><p>Our mentorship program matches upperclassmen with incoming freshman, who can help out with the social, academic, and career aspects of college. The mentorship program aims to form tight-knit friends and connections.</p>
+										<button class="button special" onclick="window.open('http://texasacm.org/forms.html?Mentorship')"><span>Sign up for our mentorship program</span></button></center>
+									</div>
+									<div class="6u$">
+										<h2>Human Resources Contact</h2>
+										<center><p>Have a complaint or concern involving our org, a member, or the CS community in general? File it here. Our HR officer takes all submissions seriously. If you prefer to remain anonymous, simply don't include your name or email.</p>
+										<button class="button special" onclick="window.open('http://texasacm.org/forms.html?Complaints')"><span>Submit Here</span></button></center>
+									</div>
 
-				<div class="section-separaters" id="become-member">
-					<br>
-					<h2>Become a Member</h2>
-					<center><p>Sign up <b>today</b>! Membership is <b>FREE</b>. Access the form below and make sure to stop by <a href="about.html#office-info" target="_blank">the office</a> to say hello!</p>
-					<button class="button special" onclick="window.open('http://texasacm.org/forms.html?join')"><span>Sign Up</span></button></center>
-				</div>
+								</div>
+							</div>
+						</div>
+					</section>
 
-				<div class="section-separaters" id="become-officer">
 					<br>
-					<h2>Become an Officer</h2>
-					<center><p>OO Applications close September 21st! Applications for Senior Officers will begin next semester. Our elections for SOs are held at the end of every Spring.</p>
-					<button class="button special" onclick="window.open('https://docs.google.com/forms/d/e/1FAIpQLSf4e64rhLtp3JhSsyQbUagflcCBbakcPj8zqWGgp0NYfbMA1w/viewform')"><span>Apply to be an Officer</span></button></center>
-				</div>
+					<br>
 
-				<div class="section-separaters" id="get-connected">
-					<br>
-					<h2>Get Connected</h2>
-					<center><p>Join our Facebook group to stay up to date with our events!</p>
-					<button class="button special" onclick="window.open('http://facebook.com/groups/texas.acm')"><span>Visit Facebook group</span></button></center>
-				</div>
-
-				<div class="section-separaters" id="join-mentorship">
-					<br>
-					<h2>Join our Mentorship Program</h2>
-					<center><p>Our mentorship program matches upperclassmen with incoming freshman, who can help out with the social, academic, and career aspects of college. The mentorship program aims to form tight-knit friends and connections.</p>
-					<button class="button special" onclick="window.open('http://texasacm.org/forms.html?Mentorship')"><span>Sign up for our mentorship program</span></button></center>
-				</div>
+				<section>
 				<div class="section-separaters" id="lockers">
 					<br><br>
 					<h2>Lockers</h2>
 						<div class="box alt">
 							<div class="row uniform 50%">
-								<div class="4u">
+								<div class="3u">
+									<span class="image fit"></span>
+								</div>
+								<div class="6u">
 									<span class="image fit"><img src="images/lockers1.jpg" alt="" /></span>
 								</div>
-								<div class="4u">
+								<div class="3u">
 									<span class="image fit"></span>
-									<h3>Locations</h3>
-									<ul>
-										<li>3rd Floor Lab</li>
-										<li>1st Floor Basement Lab</li>
-									</ul>
-								</div>
-								<div class="4u">
-									<span class="image fit"></span>
-									<h3>Cost</h3>
-									<ul>
-										<li>Small Locker: $15</li>
-										<li>Large Locker: $20</li>
-									</ul>
 								</div>
 							</div>
 						</div>
+						<br><br>
+						<div class="box alt">
+								<div class="row uniform 50%">
+									<div class="3u">
+										<span class="image fit"></span>
+									</div>
+								<div class="3u">
+									<h3>Locations</h3>
+									<ul>
+										<li>3rd Floor Lab</li>
+										<li>1st Floor Lab</li>
+									</ul>
+								</div>
+								<div class="3u">
+									<h3>Cost</h3>
+									<ul>
+										<li>Small: $15</li>
+										<li>Large: $20</li>
+									</ul>
+								</div>
+								<div class="3u">
+									<span class="image fit"></span>
+								</div>
+						</div>
+						<br><br>
+						<div>
 						<center>
 							<button class="button special" onclick="window.open('http://texasacm.org/forms.html?lockers')"><span>Register Now</span></button>
 							<p style="margin-top:0px; padding-top:0px; font-size:12px">(@utexas.edu email required for signup)</p>
 						</center>
 					</div>
-					<div class="section-separaters" id="hr-contact">
-						<br>
-						<h2>Human Resources Contact</h2>
-					<center><p>Have a complaint or concern involving our org, a member, or the CS community in general? File it here. Our HR officer takes all submissions seriously. If you prefer to remain anonymous, simply don't include your name or email.</p>
-					<button class="button special" onclick="window.open('http://texasacm.org/forms.html?Complaints')"><span>Submit Here</span></button></center>
-					</div>
 				</div>
+
+			</section>
 		</section>
 
 		<!-- Footer -->


### PR DESCRIPTION
Making better use of desktop screen real estate by employing two column look over single column look that had excess white space on the left and right. Tested at mobile resolutions in Chrome with developer tools to ensure no button/text overlap issues, etc. 