### PR TITLE
Deleting email addresses on officer cards

### DIFF
--- a/about.html
+++ b/about.html
@@ -160,9 +160,7 @@
 										<h2 class="officer-name">Robert Keele <br>Clendenin</h2>
 										<p class="officer-title">Co-President</p>
 										<p class="operational-officer-title"></p>
-										<a class="officer-mailto" href="mailto:pres@texasacm.org">Pres@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="pres@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">pres at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -172,10 +170,8 @@
 									<div class="card-info-container">
 										<h2 class="officer-name">Santiago  <br>Moreno</h2>
 										<p class="officer-title">Co-President</p>
-                                        <p class="operational-officer-title"></p>
-										<a class="officer-mailto" href="mailto:pres@texasacm.org">Pres@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="pres@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+                                       	 					<p class="operational-officer-title"></p>
+										<a class="officer-mailto">pres at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -186,10 +182,8 @@
 										<h2 class="officer-name">Nathan  <br>Huckleberry</h2>
 										<p class="officer-title">VP Academic</p>
 										<p class="officer-title"> </p>
-                                        <p class="operational-officer-title">OO: Garrett Gu</p>
-										<a class="officer-mailto" href="mailto:academics@texasacm.org">Academics@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="academics@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+                                        					<p class="operational-officer-title">OO: Garrett Gu</p>
+										<a class="officer-mailto">academics at texasacm dot org</a>
 									</div>
 								</div>
 						</div>
@@ -201,9 +195,7 @@
 										<h2 class="officer-name">Nathan <br>Jackson</h2>
 										<p class="officer-title">VP HR</p>
 										<p class="operational-officer-title">OO: Cole Harper</p>
-										<a class="officer-mailto" href="mailto:hr@texasacm.org">HR@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="hr@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">hr at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -215,9 +207,7 @@
 										<p class="officer-title">VP Corporate</p>
 										<p class="officer-title"> </p>
 										<p class="operational-officer-title">OO: Elizabeth Rodriguez</p>
-										<a class="officer-mailto" href="mailto:corporate@texasacm.org">Corporate@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="corporate@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">corporate at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -229,9 +219,7 @@
 										<p class="officer-title">VP Corporate</p>
 										<p class="officer-title"> </p>
 										<p class="operational-officer-title">OO: Elizabeth Rodriguez</p>
-										<a class="officer-mailto" href="mailto:corporate@texasacm.org">Corporate@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="corporate@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">corporate at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -243,9 +231,7 @@
 										<p class="officer-title">VP Social</p>
 										<p class="officer-title"> </p>
 										<p class="operational-officer-title">OO: Jessica Ma</p>
-										<a class="officer-mailto" href="mailto:social@texasacm.org">Social@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="social@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">social at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -259,9 +245,7 @@
 										<p class="officer-title">VP Webmaster</p>
 										<p class="officer-title"> </p>
 										<p class="operational-officer-title">OO: Lilly Tian</p>
-										<a class="officer-mailto" href="mailto:webmaster@texasacm.org">Webmaster@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="webmaster@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">webmaster at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -273,9 +257,7 @@
 										<p class="officer-title">VP Finance</p>
 										<p class="officer-title"> </p>
 										<p class="operational-officer-title">OO: Henry Liu and Zile Zhu</p>
-										<a class="officer-mailto" href="mailto:finance@texasacm.org">Finance@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="finance@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">finance at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -287,9 +269,7 @@
 										<p class="officer-title">VP Internal</p>
 										<p class="officer-title"> </p>
 										<p class="operational-officer-title">OO: Michelle Sanchez</p>
-										<a class="officer-mailto" href="mailto:internal@texasacm.org">Internal@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="internal@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">internal at texasacm dot org</a>
 									</div>
 								</div>
 							</div>
@@ -301,9 +281,7 @@
 										<p class="officer-title">VP Marketing</p>
 										<p class="officer-title"> </p>
 										<p class="operational-officer-title">OO: Manas Mishra</p>
-										<a class="officer-mailto" href="mailto:marketing@texasacm.org">Marketing@TexasACM.org</a>
-										<p><button class="button special" data-clipboard-text="marketing@texasacm.org"
-										aria-label="Copied!" onclick="showTT(this)" onmouseout="hideTT(this)">Copy Email</button></p>
+										<a class="officer-mailto">marketing at texasacm dot org</a>
 									</div>
 								</div>
 							</div>

--- a/assets/css/about-team.css
+++ b/assets/css/about-team.css
@@ -16,6 +16,7 @@
 
 .team-card {
 	box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+	padding-bottom: 2em;
 }
 
 .team-card img {

--- a/assets/css/about-team.css
+++ b/assets/css/about-team.css
@@ -16,7 +16,7 @@
 
 .team-card {
 	box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-	padding-bottom: 2em;
+	padding-bottom: 1em;
 }
 
 .team-card img {


### PR DESCRIPTION
Combat phishing attempts by deleting references to the emails and spelling out the emails instead. (For example, "webmaster at texasacm dot org.")