### PR TITLE
Brought platforms to top of website and updated years: Had to center all resources?

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1658,7 +1658,7 @@
 		display: inline-block;
 		left: 0;
 		position: absolute;
-		width: 4vw;
+		width: 100%;
 	}
 
 	h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
@@ -4826,13 +4826,13 @@
 		margin-bottom: 2em;
 		margin-left: 2em;
 		margin-right: 2em;
-		
+
 	}
 
 	.calanderImg img{
 		margin-bottom: 4em;
 		margin-top: 1em;
-		
+
 	}
 
 	.aboutBlock {

--- a/resources.html
+++ b/resources.html
@@ -64,66 +64,69 @@
 								<div class="row uniform 50%">
 									<br>
 
-                  <div class="6u">
-										<h2 id="become-member">Become a Member</h2>
-										<center><p>Sign up <b>today</b>! Membership is <b>FREE</b>. Access the form below and make sure to stop by <a href="about.html#office-info" target="_blank">the office</a> to say hello!</p>
+									<div class="12u" id="2023_Election">
+										<center>
+										<h2 style="width: 50%;">ACM 2023-2024 Elections</h2>
+										<p>Find the officer platforms for our 2023 elections.</p>
+										<button class="button special" onclick="window.open('http://texasacm.org/elections.html')"><span>View Here</span></button>
+										</center>
+									</div>
+
+                  					<div class="6u">
+										<center><h2 id="become-member">Become a Member</h2>
+										<p>Sign up <b>today</b>! Membership is <b>FREE</b>. Access the form below and make sure to stop by <a href="about.html#office-info" target="_blank">the office</a> to say hello!</p>
 										<button class="button special" onclick="window.open('http://texasacm.org/forms.html?join')"><span>Sign Up</span></button></center>
 									</div>
 
 									<div class="6u$">
-										<h2>Get Connected</h2>
-										<center><p>Connect with us through our social media pages and accounts to stay up to date with our events!</p>
+										<center><h2>Get Connected</h2>
+										<p>Connect with us through our social media pages and accounts to stay up to date with our events!</p>
 										<button class="button special" onclick="window.open('https://discord.gg/dtE2RwDb46')"><span>Discord</span></button>
 										<button class="button special" onclick="window.open('https://twitter.com/utexasACM')"><span>Twitter</span></button>
 										<button class="button special" onclick="window.open('http://facebook.com/groups/texas.acm')"><span>Facebook</span></button></center>
 									</div>
 									<div class="6u">
-										<h2 id="cs101">CS101</h2>
-										<center><p>Missed a workshop? Want to review what you learned? You can find all of the content from the workshops (like notes and slides) in our CS101 GitHub repository.</p>
+										<center><h2 id="cs101">CS101</h2>
+										<p>Missed a workshop? Want to review what you learned? You can find all of the content from the workshops (like notes and slides) in our CS101 GitHub repository.</p>
 										<button class="button special" onclick="window.open('https://github.com/utacm/cs101')"><span>GitHub Repo</span></button></center>
 									</div>
 
 									<div class="6u$" id="code-of-conduct">
-										<h2>Code of Conduct</h2>
-										<center><p>You can check out our Code of Conduct here! The Code of Conduct outlines the behaviors expected of ACM members, as well as the steps we take to ensure all UT students feel welcome and safe.</p>
+										<center><h2>Code of Conduct</h2>
+										<p>You can check out our Code of Conduct here! The Code of Conduct outlines the behaviors expected of ACM members, as well as the steps we take to ensure all UT students feel welcome and safe.</p>
 										<button class="button special" onclick="window.open('http://texasacm.org/assets/documents/code-of-conduct.pdf')"><span>View Here</span></button></center>
 									</div>
 									<div class="6u" id="bylaws">
-										<h2>Bylaws</h2>
-										<center><p>If you’re interested in reading our bylaws, you can find them here. These are the official rules that govern Texas ACM, and though our organization structure changes from year to year, we still use this document to stay true to our mission.</p>
+										<center><h2>Bylaws</h2>
+										<p>If you’re interested in reading our bylaws, you can find them here. These are the official rules that govern Texas ACM, and though our organization structure changes from year to year, we still use this document to stay true to our mission.</p>
 										<button class="button special" onclick="window.open('http://texasacm.org/assets/documents/bylaws.pdf')"><span>View Here</span></button></center>
 									</div>
 									<div class="6u$" id="hr-contact">
-										<h2>Human Resources Contact</h2>
-										<center><p>Have a complaint or concern involving our org, a member, or the CS community in general? File it here. Our HR officer takes all submissions seriously. If you prefer to remain anonymous, simply don't include your name or email.</p>
+										<center><h2>Human Resources Contact</h2>
+										<p>Have a complaint or concern involving our org, a member, or the CS community in general? File it here. Our HR officer takes all submissions seriously. If you prefer to remain anonymous, simply don't include your name or email.</p>
 										<button class="button special" onclick="window.open('http://texasacm.org/forms.html?Complaints')"><span>Submit Here</span></button></center>
 									</div>
 									<div id="resume-book" class="6u">
-										<h2> Résumé Book</h2>
-										<center><p>Add your résumé here, have companies reach out to you! NOTE: Scroll to the bottom of the page and login in the <b>Students</b> section. </p></center>
-										<center><button class="button special" onclick="window.open('https://apps.cs.utexas.edu/resume/login.scgi')"><span>Attach Résumé</span></button>
+										<center><h2> Résumé Book</h2>
+										<center><p>Add your résumé here, have companies reach out to you! NOTE: Scroll to the bottom of the page and login in the <b>Students</b> section. </p>
+										<button class="button special" onclick="window.open('https://apps.cs.utexas.edu/resume/login.scgi')"><span>Attach Résumé</span></button></center>
 										<p style="margin-top:0px; padding-top:0px; font-size:12px"></p></center>
 									</div>
 
 									<div class="6u$">
-										<h2 id="join-mentorship">Join our Mentorship Program</h2>
-										<center><p>Our mentorship program matches upperclassmen with incoming freshman, who can help out with the social, academic, and career aspects of college. The mentorship program aims to form tight-knit friends and connections.</p>
+										<center><h2 id="join-mentorship">Join our Mentorship Program</h2>
+										<p>Our mentorship program matches upperclassmen with incoming freshman, who can help out with the social, academic, and career aspects of college. The mentorship program aims to form tight-knit friends and connections.</p>
 										<button class="button special" onclick="window.open('http://texasacm.org/forms.html?Mentorship')"><span>Sign up</span></button></center>
 									</div>
 									<div class="6u">
-										<h2 id="become-officer">Become an Officer</h2>
-										<center><p>Keep an eye out for OO applications in September! For Senior Officer positions, elections are held at the end of every Spring.</p>
+										<center><h2 id="become-officer">Become an Officer</h2>
+										<p>Keep an eye out for OO applications in September! For Senior Officer positions, elections are held at the end of every Spring.</p>
 										<button class="button special" onclick="window.open('https://texasacm.org/forms/ooapp')"><span>Apply</span></button></center>
 									</div>
 									<div class="6u$" id="bylaws">
-										<h2>ACM FAQ</h2>
-										<center><p>Find answers to some commonly asked questions about ACM here.</p>
+										<center><h2>ACM FAQ</h2>
+										<p>Find answers to some commonly asked questions about ACM here.</p>
 										<button class="button special" onclick="window.open('http://texasacm.org/faq.html')"><span>View Here</span></button></center>
-									</div>
-									<div class="6u" id="2021_Election">
-										<h2>ACM 2021-2022 Elections</h2>
-										<center><p>Find the officer platforms for our 2021 elections.</p>
-										<button class="button special" onclick="window.open('http://texasacm.org/elections.html')"><span>View Here</span></button></center>
 									</div>
 
 								</div>


### PR DESCRIPTION

I did a simple update for the resources tab to make sure that we showed it was 2023-2024 and brought it to the top of the page.


I was trying to set it in the middle and to make it look consistent, I made all resources centered and increased the bottom-border to 100%. We should probably revert these changes after the election but this is a shortfix.

(Uses ::after component of h1 and could have created custom header but quicker - running into issue with overwriting)

![image](https://user-images.githubusercontent.com/22625395/231895815-321574ab-9213-44ae-a1da-c168e7c4147f.png)
